### PR TITLE
Fixed API permission scope

### DIFF
--- a/scripts/twitchautoban.sh
+++ b/scripts/twitchautoban.sh
@@ -7,7 +7,7 @@
 
 
 #requires your tokens!
-oauth="your bearer oauth token (that has moderation:manage:banned_users api permission)"
+oauth="your bearer oauth token (that has moderator:manage:banned_users api permission)"
 clientid="your api app token"
 
 #twitch helix api var


### PR DESCRIPTION
Just a minor typo, the correct scope is `moderator:manage:banned_users` (https://dev.twitch.tv/docs/api/moderation/#managing-bad-behavior)